### PR TITLE
Stamp sample attributes against case and emit event to RH

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+# Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+
+# What has changed
+<!--- What code changes has been made -->
+<!--- Has there been any refactoring -->
+<!--- What tests have been written -->
+
+# How to test?
+<!--- Describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
+<!--- Are there any automated tests that mean changes don't need to be manually changed -->
+
+# Links
+<!--- Add any links to issues (trello, github issues) -->
+<!--- Links to any documentation -->
+<!--- Links to any related PRs -->
+
+# Screenshots (if appropriate):

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.iml
 target/*
 .java-version
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/*
 *.iml
 target/*
+.java-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 script: travis_wait mvn verify jacoco:report
 
 after_success:
-- if [ "$TRAVIS_BRANCH" == "NOT-TODAY-SATAN" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+- if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
   docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
   docker tag "$SOURCE_IMAGE_NAME" "$DESTINATION_IMAGE_NAME";
   docker push "$DESTINATION_IMAGE_NAME";

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# census-rm-case-service-v2-prototype
+# census-rm-case-service-v2
 Case Service using latest versions of Java, Spring Integration and using DSL instead of XML for configuration.
 
 # How to run
+The new Case Service v2 requires Postgres, Rabbit and the IAC service to be running - you can use census-rm-docker-dev to start these dependencies.
+
 To run in development mode, make sure you specify the following in VM Options:
 ```
 -Dspring.profiles.active=dev

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # census-rm-case-service-v2-prototype
 Case Service using latest versions of Java, Spring Integration and using DSL instead of XML for configuration.
+
+# How to run
+To run in development mode, make sure you specify the following in VM Options:
+```
+-Dspring.profiles.active=dev
+```

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,12 @@
       <artifactId>orika-core</artifactId>
       <version>1.5.4</version>
     </dependency>
+    <dependency>
+      <groupId>com.godaddy</groupId>
+      <artifactId>logging</artifactId>
+      <version>1.2.5</version>
+    </dependency>
+
     <!--    Test Dependencies below this point -->
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -82,58 +82,30 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>io.fabric8</groupId>
-        <artifactId>docker-maven-plugin</artifactId>
-        <version>0.23.0</version>
+        <groupId>com.dkanejs.maven.plugins</groupId>
+        <artifactId>docker-compose-maven-plugin</artifactId>
+        <version>2.4.0</version>
         <executions>
           <execution>
-            <id>pre-stop</id>
-            <goals>
-              <goal>stop</goal>
-            </goals>
+            <id>up</id>
             <phase>pre-integration-test</phase>
+            <goals>
+              <goal>up</goal>
+            </goals>
             <configuration>
-              <images>
-                <image>
-                  <external>
-                    <type>compose</type>
-                    <basedir>${project.basedir}/src/test/resources</basedir>
-                  </external>
-                </image>
-              </images>
+              <composeFile>${project.basedir}/src/test/resources/docker-compose.yml</composeFile>
+              <detachedMode>true</detachedMode>
             </configuration>
           </execution>
           <execution>
-            <id>start</id>
+            <id>down</id>
+            <phase>post-integration-test</phase>
             <goals>
-              <goal>start</goal>
+              <goal>down</goal>
             </goals>
             <configuration>
-              <showLogs>false</showLogs>
-              <images>
-                <image>
-                  <external>
-                    <type>compose</type>
-                    <basedir>${project.basedir}/src/test/resources</basedir>
-                  </external>
-                </image>
-              </images>
-            </configuration>
-          </execution>
-          <execution>
-            <id>stop</id>
-            <goals>
-              <goal>stop</goal>
-            </goals>
-            <configuration>
-              <images>
-                <image>
-                  <external>
-                    <type>compose</type>
-                    <basedir>${project.basedir}/src/test/resources</basedir>
-                  </external>
-                </image>
-              </images>
+              <composeFile>${project.basedir}/src/test/resources/docker-compose.yml</composeFile>
+              <removeVolumes>true</removeVolumes>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,10 @@
       <artifactId>spring-integration-amqp</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,12 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>ma.glasnost.orika</groupId>
+      <artifactId>orika-core</artifactId>
+      <version>1.5.4</version>
+    </dependency>
+    <!--    Test Dependencies below this point -->
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -148,9 +148,9 @@
             </goals>
             <phase>package</phase>
             <configuration>
-              <repository>${project.artifactId}</repository>
+              <repository>eu.gcr.io/census-rm-ci/rm/${project.artifactId}</repository>
               <buildArgs>
-                <JAR_FILE>eu.gcr.io/census-rm-ci/rm/${project.build.finalName}.jar</JAR_FILE>
+                <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
               </buildArgs>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
             <configuration>
               <repository>${project.artifactId}</repository>
               <buildArgs>
-                <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+                <JAR_FILE>eu.gcr.io/census-rm-ci/rm/${project.build.finalName}.jar</JAR_FILE>
               </buildArgs>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>uk.gov.ons.census.casesvc</groupId>
-  <artifactId>census-rm-case-service-v2</artifactId>
+  <artifactId>census-rm-casesvc-v2</artifactId>
   <version>1.0-SNAPSHOT</version>
 
   <parent>

--- a/src/main/java/uk/gov/ons/census/casesvc/client/InternetAccessCodeSvcClient.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/client/InternetAccessCodeSvcClient.java
@@ -1,0 +1,84 @@
+package uk.gov.ons.census.casesvc.client;
+
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+import uk.gov.ons.census.casesvc.model.dto.CreateInternetAccessCodeDTO;
+
+/** The impl of the service which calls the IAC service via REST */
+@Component
+public class InternetAccessCodeSvcClient {
+  @Value("${iacservice.generate-iacs-path}")
+  private String generateIacsPath;
+
+  @Value("${iacservice.connection.scheme}")
+  private String scheme;
+
+  @Value("${iacservice.connection.host}")
+  private String host;
+
+  @Value("${iacservice.connection.port}")
+  private String port;
+
+  @Value("${iacservice.connection.username}")
+  private String username;
+
+  @Value("${iacservice.connection.password}")
+  private String password;
+
+  public List<String> generateIACs(int count) {
+
+    RestTemplate restTemplate = new RestTemplate();
+    UriComponents uriComponents = createUriComponents(generateIacsPath, null);
+
+    CreateInternetAccessCodeDTO createCodesDTO = new CreateInternetAccessCodeDTO(count, "SYSTEM");
+    HttpEntity<CreateInternetAccessCodeDTO> httpEntity = createHttpEntity(createCodesDTO);
+
+    ResponseEntity<String[]> responseEntity =
+        restTemplate.exchange(uriComponents.toUri(), HttpMethod.POST, httpEntity, String[].class);
+    return Arrays.asList(responseEntity.getBody());
+  }
+
+  public UriComponents createUriComponents(
+      String path, MultiValueMap<String, String> queryParams, Object... pathParams) {
+    UriComponents uriComponentsWithOutQueryParams =
+        UriComponentsBuilder.newInstance()
+            .scheme(scheme)
+            .host(host)
+            .port(port)
+            .path(path)
+            .buildAndExpand(pathParams);
+    return UriComponentsBuilder.newInstance()
+        .uriComponents(uriComponentsWithOutQueryParams)
+        .queryParams(queryParams)
+        .build()
+        .encode();
+  }
+
+  private <H> HttpEntity<H> createHttpEntity(H entity) {
+    return new HttpEntity(entity, getHttpHeaders());
+  }
+
+  private HttpHeaders getHttpHeaders() {
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("Accept", "application/json");
+    headers.set("Content-Type", "application/json");
+    String auth = username + ":" + password;
+    byte[] encodedAuth = Base64.getEncoder().encode(auth.getBytes(Charset.forName("US-ASCII")));
+    String authHeader = "Basic " + new String(encodedAuth);
+    headers.set("Authorization", authHeader);
+
+    return headers;
+  }
+}

--- a/src/main/java/uk/gov/ons/census/casesvc/client/InternetAccessCodeSvcClient.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/client/InternetAccessCodeSvcClient.java
@@ -19,6 +19,8 @@ import uk.gov.ons.census.casesvc.model.dto.CreateInternetAccessCodeDTO;
 /** The impl of the service which calls the IAC service via REST */
 @Component
 public class InternetAccessCodeSvcClient {
+  private static final String CREATED_BY = "SYSTEM";
+
   @Value("${iacservice.generate-iacs-path}")
   private String generateIacsPath;
 
@@ -42,7 +44,7 @@ public class InternetAccessCodeSvcClient {
     RestTemplate restTemplate = new RestTemplate();
     UriComponents uriComponents = createUriComponents(generateIacsPath, null);
 
-    CreateInternetAccessCodeDTO createCodesDTO = new CreateInternetAccessCodeDTO(count, "SYSTEM");
+    CreateInternetAccessCodeDTO createCodesDTO = new CreateInternetAccessCodeDTO(count, CREATED_BY);
     HttpEntity<CreateInternetAccessCodeDTO> httpEntity = createHttpEntity(createCodesDTO);
 
     ResponseEntity<String[]> responseEntity =
@@ -50,7 +52,7 @@ public class InternetAccessCodeSvcClient {
     return Arrays.asList(responseEntity.getBody());
   }
 
-  public UriComponents createUriComponents(
+  private UriComponents createUriComponents(
       String path, MultiValueMap<String, String> queryParams, Object... pathParams) {
     UriComponents uriComponentsWithOutQueryParams =
         UriComponentsBuilder.newInstance()

--- a/src/main/java/uk/gov/ons/census/casesvc/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/config/AppConfig.java
@@ -63,8 +63,7 @@ public class AppConfig {
 
   @Bean
   public AmqpAdmin amqpAdmin(ConnectionFactory connectionFactory) {
-    RabbitAdmin rabbitAdmin = new RabbitAdmin(connectionFactory);
-    return rabbitAdmin;
+    return new RabbitAdmin(connectionFactory);
   }
 
   @Bean

--- a/src/main/java/uk/gov/ons/census/casesvc/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/config/AppConfig.java
@@ -22,14 +22,14 @@ public class AppConfig {
   private String inboundQueue;
 
   @Bean
-  public MessageChannel amqpInputChannel() {
+  public MessageChannel caseSampleInputChannel() {
     return new DirectChannel();
   }
 
   @Bean
   public AmqpInboundChannelAdapter inbound(
       SimpleMessageListenerContainer listenerContainer,
-      @Qualifier("amqpInputChannel") MessageChannel channel) {
+      @Qualifier("caseSampleInputChannel") MessageChannel channel) {
     AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(listenerContainer);
     adapter.setOutputChannel(channel);
     return adapter;
@@ -37,16 +37,15 @@ public class AppConfig {
 
   @Bean
   public RabbitTemplate rabbitTemplate(
-      ConnectionFactory connectionFactory,
-      Jackson2JsonMessageConverter producerJackson2MessageConverter) {
+      ConnectionFactory connectionFactory, Jackson2JsonMessageConverter messageConverter) {
     RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
-    rabbitTemplate.setMessageConverter(producerJackson2MessageConverter);
+    rabbitTemplate.setMessageConverter(messageConverter);
     rabbitTemplate.setChannelTransacted(true);
     return rabbitTemplate;
   }
 
   @Bean
-  public Jackson2JsonMessageConverter producerJackson2MessageConverter() {
+  public Jackson2JsonMessageConverter messageConverter() {
     return new Jackson2JsonMessageConverter();
   }
 

--- a/src/main/java/uk/gov/ons/census/casesvc/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/config/AppConfig.java
@@ -1,5 +1,8 @@
 package uk.gov.ons.census.casesvc.config;
 
+import ma.glasnost.orika.MapperFacade;
+import ma.glasnost.orika.MapperFactory;
+import ma.glasnost.orika.impl.DefaultMapperFactory;
 import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
@@ -62,5 +65,12 @@ public class AppConfig {
   public AmqpAdmin amqpAdmin(ConnectionFactory connectionFactory) {
     RabbitAdmin rabbitAdmin = new RabbitAdmin(connectionFactory);
     return rabbitAdmin;
+  }
+
+  @Bean
+  public MapperFacade mapperFacade() {
+    MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
+
+    return mapperFactory.getMapperFacade();
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/iac/IacDispenser.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/iac/IacDispenser.java
@@ -57,6 +57,7 @@ public class IacDispenser implements Runnable {
     } catch (Exception exception) {
       // This is more of a warning because it's recoverable but it can cause an error
       //      log.error("Unexpected exception when requesting IAC codes to top up pool", exception);
+      exception.printStackTrace();
     } finally {
       isFetchingIacCodes = false;
     }

--- a/src/main/java/uk/gov/ons/census/casesvc/iac/IacDispenser.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/iac/IacDispenser.java
@@ -1,0 +1,64 @@
+package uk.gov.ons.census.casesvc.iac;
+
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.ons.census.casesvc.client.InternetAccessCodeSvcClient;
+
+@Component
+public class IacDispenser implements Runnable {
+  private InternetAccessCodeSvcClient internetAccessCodeSvcClient;
+  private BlockingQueue<String> iacCodePool = new LinkedBlockingQueue<>();
+  private boolean isFetchingIacCodes = false;
+
+  @Value("${iacservice.pool-size-min}")
+  private int iacPoolSizeMin;
+
+  @Value("${iacservice.pool-size-max}")
+  private int iacPoolSizeMax;
+
+  public IacDispenser(InternetAccessCodeSvcClient internetAccessCodeSvcClient) {
+    this.internetAccessCodeSvcClient = internetAccessCodeSvcClient;
+  }
+
+  public String getIacCode() {
+    topUpPoolIfNecessary();
+
+    try {
+      return iacCodePool.take();
+    } catch (InterruptedException e) {
+      throw new RuntimeException("Thread shut down while waiting for IAC code");
+    }
+  }
+
+  // This function has to be synchronized to protect against a dead-heat request for a top-up
+  private synchronized void topUpPoolIfNecessary() {
+    // Theoretically we could end up with more threads waiting for IAC codes than we've requested
+    // so we should never have more worker threads than the max pool size.
+    if (!isFetchingIacCodes && iacCodePool.size() < iacPoolSizeMin) {
+      isFetchingIacCodes = true; // Don't ask for more codes until the last request has completed
+
+      Thread thread = new Thread(this);
+      thread.run();
+    }
+  }
+
+  @Override
+  public void run() {
+    try {
+      // In theory this could fail, but it's retryable and it will recover so long as requests for
+      // IAC codes continue to arrive. In the worst case scenario messages will build up on the
+      // Rabbit queue until somebody spots the errors and resolves the issue
+      List<String> generatedIacCodes = internetAccessCodeSvcClient.generateIACs(iacPoolSizeMax);
+
+      iacCodePool.addAll(generatedIacCodes);
+    } catch (Exception exception) {
+      // This is more of a warning because it's recoverable but it can cause an error
+      //      log.error("Unexpected exception when requesting IAC codes to top up pool", exception);
+    } finally {
+      isFetchingIacCodes = false;
+    }
+  }
+}

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.transaction.annotation.Transactional;
-import uk.gov.ons.census.casesvc.iac.IacDispenser;
+import uk.gov.ons.census.casesvc.utility.IacDispenser;
 import uk.gov.ons.census.casesvc.model.dto.Address;
 import uk.gov.ons.census.casesvc.model.dto.CaseCreatedEvent;
 import uk.gov.ons.census.casesvc.model.dto.CollectionCase;
@@ -34,6 +34,7 @@ public class SampleReceiver {
   private RabbitTemplate rabbitTemplate;
   private IacDispenser iacDispenser;
   private QidCreator qidCreator;
+  private MapperFacade mapperFacade;
 
   @Value("${queueconfig.emit-case-event-exchange}")
   private String emitCaseEventExchange;
@@ -44,13 +45,15 @@ public class SampleReceiver {
       EventRepository eventRepository,
       RabbitTemplate rabbitTemplate,
       IacDispenser iacDispenser,
-      QidCreator qidCreator) {
+      QidCreator qidCreator,
+      MapperFacade mapperFacade) {
     this.caseRepository = caseRepository;
     this.rabbitTemplate = rabbitTemplate;
     this.iacDispenser = iacDispenser;
     this.uacQidLinkRepository = uacQidLinkRepository;
     this.eventRepository = eventRepository;
     this.qidCreator = qidCreator;
+    this.mapperFacade = mapperFacade;
   }
 
   @Transactional

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
@@ -1,16 +1,18 @@
 package uk.gov.ons.census.casesvc.messaging;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.ons.census.casesvc.iac.IacDispenser;
 import uk.gov.ons.census.casesvc.model.dto.Address;
 import uk.gov.ons.census.casesvc.model.dto.CaseCreatedEvent;
 import uk.gov.ons.census.casesvc.model.dto.CollectionCase;
+import uk.gov.ons.census.casesvc.model.dto.CreateCaseSample;
 import uk.gov.ons.census.casesvc.model.dto.Event;
-import uk.gov.ons.census.casesvc.model.dto.FooBar;
 import uk.gov.ons.census.casesvc.model.dto.Payload;
 import uk.gov.ons.census.casesvc.model.entity.Case;
 import uk.gov.ons.census.casesvc.model.entity.CaseStatus;
@@ -20,44 +22,73 @@ import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 public class SampleReceiver {
   private CaseRepository caseRepository;
   private RabbitTemplate rabbitTemplate;
+  private IacDispenser iacDispenser;
 
   @Value("${queueconfig.emit-case-event-exchange}")
   private String emitCaseEventExchange;
 
-  public SampleReceiver(CaseRepository caseRepository, RabbitTemplate rabbitTemplate) {
+  public SampleReceiver(
+      CaseRepository caseRepository, RabbitTemplate rabbitTemplate, IacDispenser iacDispenser) {
     this.caseRepository = caseRepository;
     this.rabbitTemplate = rabbitTemplate;
+    this.iacDispenser = iacDispenser;
   }
 
   @Transactional
   @ServiceActivator(inputChannel = "amqpInputChannel")
-  public void receiveMessage(FooBar fooBar) {
-    System.out.println(fooBar.getFoo());
+  public void receiveMessage(CreateCaseSample createCaseSample) {
     Case caze = new Case();
     caze.setId(UUID.randomUUID());
-    caze.setStuff(fooBar.getFoo());
+    caze.setAbpCode(createCaseSample.getAbpCode());
+    caze.setActionPlanId(createCaseSample.getActionPlanId());
+    caze.setAddressLevel(createCaseSample.getAddressLevel());
+    caze.setAddressLine1(createCaseSample.getAddressLine1());
+    caze.setAddressLine2(createCaseSample.getAddressLine1());
+    caze.setAddressLine2(createCaseSample.getAddressLine1());
+    caze.setAddressType(createCaseSample.getAddressType());
+    caze.setArid(createCaseSample.getArid());
+    caze.setCollectionExerciseId(createCaseSample.getCollectionExerciseId());
+    caze.setEstabArid(createCaseSample.getEstabArid());
+    caze.setEstabType(createCaseSample.getEstabType());
+    caze.setHtcDigital(createCaseSample.getHtcDigital());
+    caze.setHtcWillingness(createCaseSample.getHtcWillingness());
+    caze.setLad18cd(createCaseSample.getLad18cd());
+    caze.setLatitude(createCaseSample.getLatitude());
+    caze.setLongitude(createCaseSample.getLongitude());
+    caze.setLsoa11cd(createCaseSample.getLsoa11cd());
+    caze.setMsoa11cd(createCaseSample.getMsoa11cd());
+    caze.setOa11cd(createCaseSample.getOa11cd());
+    caze.setOrganisationName(createCaseSample.getOrganisationName());
+    caze.setPostcode(createCaseSample.getPostcode());
+    caze.setRgn10cd(createCaseSample.getRgn10cd());
+    caze.setTownName(createCaseSample.getTownName());
+    caze.setTreatmentCode(createCaseSample.getTreatmentCode());
+    caze.setUprn(createCaseSample.getUprn());
     caze.setStatus(CaseStatus.NOTSTARTED);
+    caze.setUacCode(iacDispenser.getIacCode());
     caseRepository.save(caze);
+
+    LocalDateTime now = LocalDateTime.now();
 
     Event event = new Event();
     event.setChannel("rm");
-    event.setDateTime("2019-04-01T12:00Z");
+    event.setDateTime(now.toString());
     event.setTransactionId(UUID.randomUUID().toString());
     event.setType("CaseCreated");
     Address address = new Address();
-    address.setAddressLine1("1 Main Street");
-    address.setAddressLine2("Upper Upperingham");
-    address.setAddressLine2("Lower Lowerington");
-    address.setAddressType("CE");
-    address.setArid("XXXXX");
+    address.setAddressLine1(createCaseSample.getAddressLine1());
+    address.setAddressLine2(createCaseSample.getAddressLine2());
+    address.setAddressLine3(createCaseSample.getAddressLine3());
+    address.setAddressType(createCaseSample.getAddressType());
+    address.setArid(createCaseSample.getArid());
     address.setCountry("E");
-    address.setEstabType("XXX");
-    address.setLatitude("50.863849");
-    address.setLongitude("-1.229710");
-    address.setPostcode("UP103UP");
-    address.setTownName("Royal Midtowncastlecesteringshirehampton-upon-Twiddlebottom");
+    address.setEstabType(createCaseSample.getEstabType());
+    address.setLatitude(createCaseSample.getLatitude());
+    address.setLongitude(createCaseSample.getLongitude());
+    address.setPostcode(createCaseSample.getPostcode());
+    address.setTownName(createCaseSample.getTownName());
     CollectionCase collectionCase = new CollectionCase();
-    collectionCase.setActionableFrom("2019-04-01T12:00Z");
+    collectionCase.setActionableFrom(now.toString());
     collectionCase.setAddress(address);
     collectionCase.setCaseRef("10000000010");
     collectionCase.setCollectionExerciseId(UUID.randomUUID().toString());

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
@@ -68,10 +68,6 @@ public class SampleReceiver {
   }
 
   private Case persistToDatabase(CreateCaseSample createCaseSample) {
-    MapperFactory mapperFactory = new DefaultMapperFactory.Builder().build();
-
-    MapperFacade mapperFacade = mapperFactory.getMapperFacade();
-
     Case caze = mapperFacade.map(createCaseSample, Case.class);
     caze.setCaseId(UUID.randomUUID());
     caze.setState(CaseState.ACTIONABLE);
@@ -115,7 +111,7 @@ public class SampleReceiver {
     address.setAddressLine3(caze.getAddressLine3());
     address.setAddressType(caze.getAddressType());
     address.setArid(caze.getArid());
-    address.setCountry(caze.getRgn().substring(0, 1));
+    address.setRegion(caze.getRgn().substring(0, 1));
     address.setEstabType(caze.getEstabType());
     address.setLatitude(caze.getLatitude());
     address.setLongitude(caze.getLongitude());

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
@@ -89,8 +89,7 @@ public class SampleReceiver {
     uacQidLink = uacQidLinkRepository.saveAndFlush(uacQidLink);
 
     String qid =
-        qidCreator.createQid(
-            createCaseSample.getTreatmentCode(), uacQidLink.getUniqueNumber());
+        qidCreator.createQid(createCaseSample.getTreatmentCode(), uacQidLink.getUniqueNumber());
     uacQidLink.setQid(qid);
     uacQidLinkRepository.save(uacQidLink);
 

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
@@ -1,7 +1,6 @@
 package uk.gov.ons.census.casesvc.messaging;
 
 import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.Date;
 import java.util.UUID;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
@@ -132,8 +132,6 @@ public class SampleReceiver {
 
     rabbitTemplate.convertAndSend(emitCaseEventExchange, "", caseCreatedEvent);
 
-    System.out.println("STORED AND SENT");
-
     // Enable the code below to prove that the DB txn and the Rabbit txn are part of the same txn
     //    Random random = new Random();
     //    int randomNumber = random.nextInt(1000);

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
@@ -36,13 +36,13 @@ public class SampleReceiver {
   private static final String EVENT_CHANNEL = "RM";
   private static final String EVENT_DESCRIPTION = "Case created";
 
-  private CaseRepository caseRepository;
-  private UacQidLinkRepository uacQidLinkRepository;
-  private EventRepository eventRepository;
-  private RabbitTemplate rabbitTemplate;
-  private IacDispenser iacDispenser;
-  private QidCreator qidCreator;
-  private MapperFacade mapperFacade;
+  private final CaseRepository caseRepository;
+  private final UacQidLinkRepository uacQidLinkRepository;
+  private final EventRepository eventRepository;
+  private final RabbitTemplate rabbitTemplate;
+  private final IacDispenser iacDispenser;
+  private final QidCreator qidCreator;
+  private final MapperFacade mapperFacade;
 
   @Value("${queueconfig.emit-case-event-exchange}")
   private String emitCaseEventExchange;

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
@@ -4,14 +4,11 @@ import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.UUID;
 import ma.glasnost.orika.MapperFacade;
-import ma.glasnost.orika.MapperFactory;
-import ma.glasnost.orika.impl.DefaultMapperFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.transaction.annotation.Transactional;
-import uk.gov.ons.census.casesvc.utility.IacDispenser;
 import uk.gov.ons.census.casesvc.model.dto.Address;
 import uk.gov.ons.census.casesvc.model.dto.CaseCreatedEvent;
 import uk.gov.ons.census.casesvc.model.dto.CollectionCase;
@@ -24,6 +21,7 @@ import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
 import uk.gov.ons.census.casesvc.model.repository.EventRepository;
 import uk.gov.ons.census.casesvc.model.repository.UacQidLinkRepository;
+import uk.gov.ons.census.casesvc.utility.IacDispenser;
 import uk.gov.ons.census.casesvc.utility.QidCreator;
 
 @MessageEndpoint

--- a/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/messaging/SampleReceiver.java
@@ -47,9 +47,6 @@ public class SampleReceiver {
   @Value("${queueconfig.emit-case-event-exchange}")
   private String emitCaseEventExchange;
 
-  @Value("${qid.tranche-identifier}")
-  private int trancheIdentifier;
-
   public SampleReceiver(
       CaseRepository caseRepository,
       UacQidLinkRepository uacQidLinkRepository,
@@ -93,7 +90,7 @@ public class SampleReceiver {
 
     String qid =
         qidCreator.createQid(
-            createCaseSample.getTreatmentCode(), trancheIdentifier, uacQidLink.getUniqueNumber());
+            createCaseSample.getTreatmentCode(), uacQidLink.getUniqueNumber());
     uacQidLink.setQid(qid);
     uacQidLinkRepository.save(uacQidLink);
 

--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/Address.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/Address.java
@@ -9,7 +9,7 @@ public class Address {
   private String addressLine3;
   private String townName;
   private String postcode;
-  private String country;
+  private String region;
   private String latitude;
   private String longitude;
   private String uprn;

--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/CollectionCase.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/CollectionCase.java
@@ -8,7 +8,6 @@ public class CollectionCase {
   private String caseRef;
   private String survey;
   private String collectionExerciseId;
-  private String sampleUnitRef;
   private Address address;
   private String state;
   private String actionableFrom;

--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/CreateCaseSample.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/CreateCaseSample.java
@@ -1,0 +1,32 @@
+package uk.gov.ons.census.casesvc.model.dto;
+
+import lombok.Data;
+
+@Data
+public class CreateCaseSample {
+  String arid;
+  String estabArid;
+  String uprn;
+  String addressType;
+  String estabType;
+  String addressLevel;
+  String abpCode;
+  String organisationName;
+  String addressLine1;
+  String addressLine2;
+  String addressLine3;
+  String townName;
+  String postcode;
+  String latitude;
+  String longitude;
+  String oa11cd;
+  String lsoa11cd;
+  String msoa11cd;
+  String lad18cd;
+  String rgn10cd;
+  String htcWillingness;
+  String htcDigital;
+  String treatmentCode;
+  String collectionExerciseId;
+  String actionPlanId;
+}

--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/CreateCaseSample.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/CreateCaseSample.java
@@ -19,11 +19,11 @@ public class CreateCaseSample {
   String postcode;
   String latitude;
   String longitude;
-  String oa11cd;
-  String lsoa11cd;
-  String msoa11cd;
-  String lad18cd;
-  String rgn10cd;
+  String oa;
+  String lsoa;
+  String msoa;
+  String lad;
+  String rgn;
   String htcWillingness;
   String htcDigital;
   String treatmentCode;

--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/CreateInternetAccessCodeDTO.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/CreateInternetAccessCodeDTO.java
@@ -1,0 +1,16 @@
+package uk.gov.ons.census.casesvc.model.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+public class CreateInternetAccessCodeDTO {
+
+  private Integer count;
+
+  private String createdBy;
+}

--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/Event.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/Event.java
@@ -5,6 +5,7 @@ import lombok.Data;
 @Data
 public class Event {
   private String type;
+  private String source;
   private String channel;
   private String dateTime;
   private String transactionId;

--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/Event.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/Event.java
@@ -4,7 +4,7 @@ import lombok.Data;
 
 @Data
 public class Event {
-  private String type;
+  private EventType type;
   private String source;
   private String channel;
   private String dateTime;

--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/EventType.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/EventType.java
@@ -1,0 +1,5 @@
+package uk.gov.ons.census.casesvc.model.dto;
+
+public enum EventType {
+  CASE_CREATED;
+}

--- a/src/main/java/uk/gov/ons/census/casesvc/model/dto/FooBar.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/dto/FooBar.java
@@ -1,9 +1,0 @@
-package uk.gov.ons.census.casesvc.model.dto;
-
-import lombok.Data;
-
-@Data
-public class FooBar {
-  private String foo;
-  private String test;
-}

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
@@ -1,10 +1,13 @@
 package uk.gov.ons.census.casesvc.model.entity;
 
+import java.util.List;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import lombok.Data;
 
@@ -44,15 +47,15 @@ public class Case {
 
   @Column private String longitude;
 
-  @Column private String oa11cd;
+  @Column private String oa;
 
-  @Column private String lsoa11cd;
+  @Column private String lsoa;
 
-  @Column private String msoa11cd;
+  @Column private String msoa;
 
-  @Column private String lad18cd;
+  @Column private String lad;
 
-  @Column private String rgn10cd;
+  @Column private String rgn;
 
   @Column private String htcWillingness;
 
@@ -64,7 +67,8 @@ public class Case {
 
   @Column private String actionPlanId;
 
-  @Column private String uacCode;
+  @Column @Enumerated(EnumType.STRING) private CaseState state;
 
-  @Column @Enumerated private CaseStatus status;
+  @OneToMany(mappedBy = "caze")
+  List<UacQidLink> uacQidLinks;
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
@@ -6,8 +6,11 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import lombok.Data;
 
@@ -15,7 +18,13 @@ import lombok.Data;
 @Entity
 @Table(name = "cases")
 public class Case {
-  @Id private UUID id;
+
+  @Id
+  @SequenceGenerator(name = "caseRefGenerator", initialValue = 100000000)
+  @GeneratedValue(generator = "caseRefGenerator", strategy = GenerationType.SEQUENCE)
+  private Long caseRef;
+
+  @Column private UUID caseId;
 
   @Column private String arid;
 

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
@@ -22,7 +22,7 @@ public class Case {
   @Id
   @SequenceGenerator(name = "caseRefGenerator", initialValue = 10000000)
   @GeneratedValue(generator = "caseRefGenerator", strategy = GenerationType.SEQUENCE)
-  private Long caseRef;
+  private long caseRef;
 
   @Column private UUID caseId;
 

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
@@ -67,7 +67,9 @@ public class Case {
 
   @Column private String actionPlanId;
 
-  @Column @Enumerated(EnumType.STRING) private CaseState state;
+  @Column
+  @Enumerated(EnumType.STRING)
+  private CaseState state;
 
   @OneToMany(mappedBy = "caze")
   List<UacQidLink> uacQidLinks;

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
@@ -20,7 +20,7 @@ import lombok.Data;
 public class Case {
 
   @Id
-  @SequenceGenerator(name = "caseRefGenerator", initialValue = 100000000)
+  @SequenceGenerator(name = "caseRefGenerator", initialValue = 10000000)
   @GeneratedValue(generator = "caseRefGenerator", strategy = GenerationType.SEQUENCE)
   private Long caseRef;
 

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/Case.java
@@ -14,7 +14,57 @@ import lombok.Data;
 public class Case {
   @Id private UUID id;
 
-  @Column private String stuff;
+  @Column private String arid;
+
+  @Column private String estabArid;
+
+  @Column private String uprn;
+
+  @Column private String addressType;
+
+  @Column private String estabType;
+
+  @Column private String addressLevel;
+
+  @Column private String abpCode;
+
+  @Column private String organisationName;
+
+  @Column private String addressLine1;
+
+  @Column private String addressLine2;
+
+  @Column private String addressLine3;
+
+  @Column private String townName;
+
+  @Column private String postcode;
+
+  @Column private String latitude;
+
+  @Column private String longitude;
+
+  @Column private String oa11cd;
+
+  @Column private String lsoa11cd;
+
+  @Column private String msoa11cd;
+
+  @Column private String lad18cd;
+
+  @Column private String rgn10cd;
+
+  @Column private String htcWillingness;
+
+  @Column private String htcDigital;
+
+  @Column private String treatmentCode;
+
+  @Column private String collectionExerciseId;
+
+  @Column private String actionPlanId;
+
+  @Column private String uacCode;
 
   @Column @Enumerated private CaseStatus status;
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/CaseState.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/CaseState.java
@@ -1,9 +1,5 @@
 package uk.gov.ons.census.casesvc.model.entity;
 
 public enum CaseState {
-  ACTIONABLE,
-  NOTSTARTED,
-  INPROGRESS,
-  COMPLETE,
-  REFUSED
+  ACTIONABLE
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/CaseState.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/CaseState.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.census.casesvc.model.entity;
 
-public enum CaseStatus {
+public enum CaseState {
+  ACTIONABLE,
   NOTSTARTED,
   INPROGRESS,
   COMPLETE,

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/Event.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/Event.java
@@ -11,16 +11,11 @@ import lombok.Data;
 @Data
 @Entity
 public class Event {
-  @Id
-  private UUID id;
+  @Id private UUID id;
 
-  @ManyToOne
-  private UacQidLink uacQidLink;
+  @ManyToOne private UacQidLink uacQidLink;
 
-  @Column
-  private Date eventDate;
+  @Column private Date eventDate;
 
-  @Column
-  private String eventDescription;
-
+  @Column private String eventDescription;
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/Event.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/Event.java
@@ -1,0 +1,26 @@
+package uk.gov.ons.census.casesvc.model.entity;
+
+import java.util.Date;
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import lombok.Data;
+
+@Data
+@Entity
+public class Event {
+  @Id
+  private UUID id;
+
+  @ManyToOne
+  private UacQidLink uacQidLink;
+
+  @Column
+  private Date eventDate;
+
+  @Column
+  private String eventDescription;
+
+}

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/UacQidLink.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/UacQidLink.java
@@ -20,7 +20,7 @@ public class UacQidLink {
   @Generated(GenerationTime.INSERT)
   private Long uniqueNumber;
 
-  @Column private Long qid;
+  @Column private String qid;
 
   @Column private String uac;
 

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/UacQidLink.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/UacQidLink.java
@@ -20,6 +20,6 @@ public class UacQidLink {
 
   @ManyToOne private Case caze;
 
-  @OneToMany(mappedBy="uacQidLink")
+  @OneToMany(mappedBy = "uacQidLink")
   private List<Event> events;
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/UacQidLink.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/UacQidLink.java
@@ -1,0 +1,25 @@
+package uk.gov.ons.census.casesvc.model.entity;
+
+import java.util.List;
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import lombok.Data;
+
+@Data
+@Entity
+public class UacQidLink {
+  @Id private UUID id;
+
+  @Column private Long qid;
+
+  @Column private String uac;
+
+  @ManyToOne private Case caze;
+
+  @OneToMany(mappedBy="uacQidLink")
+  private List<Event> events;
+}

--- a/src/main/java/uk/gov/ons/census/casesvc/model/entity/UacQidLink.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/entity/UacQidLink.java
@@ -8,11 +8,17 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import lombok.Data;
+import org.hibernate.annotations.Generated;
+import org.hibernate.annotations.GenerationTime;
 
 @Data
 @Entity
 public class UacQidLink {
   @Id private UUID id;
+
+  @Column(columnDefinition = "serial")
+  @Generated(GenerationTime.INSERT)
+  private Long uniqueNumber;
 
   @Column private Long qid;
 

--- a/src/main/java/uk/gov/ons/census/casesvc/model/repository/EventRepository.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/repository/EventRepository.java
@@ -4,4 +4,5 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.census.casesvc.model.entity.Event;
 
-public interface EventRepository extends JpaRepository<Event, UUID> {}
+public interface EventRepository extends JpaRepository<Event, UUID> {
+}

--- a/src/main/java/uk/gov/ons/census/casesvc/model/repository/EventRepository.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/repository/EventRepository.java
@@ -4,5 +4,4 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import uk.gov.ons.census.casesvc.model.entity.Event;
 
-public interface EventRepository extends JpaRepository<Event, UUID> {
-}
+public interface EventRepository extends JpaRepository<Event, UUID> {}

--- a/src/main/java/uk/gov/ons/census/casesvc/model/repository/EventRepository.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/repository/EventRepository.java
@@ -1,0 +1,8 @@
+package uk.gov.ons.census.casesvc.model.repository;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import uk.gov.ons.census.casesvc.model.entity.Event;
+
+public interface EventRepository extends JpaRepository<Event, UUID> {
+}

--- a/src/main/java/uk/gov/ons/census/casesvc/model/repository/UacQidLinkRepository.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/model/repository/UacQidLinkRepository.java
@@ -1,0 +1,7 @@
+package uk.gov.ons.census.casesvc.model.repository;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
+
+public interface UacQidLinkRepository extends JpaRepository<UacQidLink, UUID> {}

--- a/src/main/java/uk/gov/ons/census/casesvc/utility/IacDispenser.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/utility/IacDispenser.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.census.casesvc.utility;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -9,6 +11,8 @@ import uk.gov.ons.census.casesvc.client.InternetAccessCodeSvcClient;
 
 @Component
 public class IacDispenser implements Runnable {
+  private static final Logger log = LoggerFactory.getLogger(IacDispenser.class);
+
   private InternetAccessCodeSvcClient internetAccessCodeSvcClient;
   private BlockingQueue<String> iacCodePool = new LinkedBlockingQueue<>();
   private boolean isFetchingIacCodes = false;
@@ -56,8 +60,7 @@ public class IacDispenser implements Runnable {
       iacCodePool.addAll(generatedIacCodes);
     } catch (Exception exception) {
       // This is more of a warning because it's recoverable but it can cause an error
-      //      log.error("Unexpected exception when requesting IAC codes to top up pool", exception);
-      exception.printStackTrace();
+      log.error("Unexpected exception when requesting IAC codes to top up pool", exception);
     } finally {
       isFetchingIacCodes = false;
     }

--- a/src/main/java/uk/gov/ons/census/casesvc/utility/IacDispenser.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/utility/IacDispenser.java
@@ -13,8 +13,8 @@ import uk.gov.ons.census.casesvc.client.InternetAccessCodeSvcClient;
 public class IacDispenser implements Runnable {
   private static final Logger log = LoggerFactory.getLogger(IacDispenser.class);
 
-  private InternetAccessCodeSvcClient internetAccessCodeSvcClient;
-  private BlockingQueue<String> iacCodePool = new LinkedBlockingQueue<>();
+  private final InternetAccessCodeSvcClient internetAccessCodeSvcClient;
+  private final BlockingQueue<String> iacCodePool = new LinkedBlockingQueue<>();
   private boolean isFetchingIacCodes = false;
 
   @Value("${iacservice.pool-size-min}")

--- a/src/main/java/uk/gov/ons/census/casesvc/utility/IacDispenser.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/utility/IacDispenser.java
@@ -1,4 +1,4 @@
-package uk.gov.ons.census.casesvc.iac;
+package uk.gov.ons.census.casesvc.utility;
 
 import java.util.List;
 import java.util.concurrent.BlockingQueue;

--- a/src/main/java/uk/gov/ons/census/casesvc/utility/QidCreator.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/utility/QidCreator.java
@@ -1,16 +1,33 @@
 package uk.gov.ons.census.casesvc.utility;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class QidCreator {
 
+  @Value("${qid.modulus}")
+  private int modulus;
+
+  @Value("${qid.factor}")
+  private int factor;
+
   public long createQid(int questionnaireType, int trancheIdentifier, long uniqueNumber) {
+    String sourceDigits =
+        String.format("%02d%01d%011d", questionnaireType, trancheIdentifier, uniqueNumber);
 
-    int checkDigits = 99;
+    int checkDigits = calculateCheckDigits(sourceDigits);
 
-    return Long.parseLong(
-        String.format(
-            "%02d%01d%011d%02d", questionnaireType, trancheIdentifier, uniqueNumber, checkDigits));
+    return Long.parseLong(String.format("%s%02d", sourceDigits, checkDigits));
+  }
+
+  private int calculateCheckDigits(String sourceDigits) {
+    int remainder = sourceDigits.charAt(0);
+
+    for (int charIdx = 1; charIdx < sourceDigits.length(); charIdx++) {
+      int temp = sourceDigits.charAt(charIdx);
+      remainder = (remainder * factor + temp) % modulus;
+    }
+    return remainder % modulus;
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/utility/QidCreator.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/utility/QidCreator.java
@@ -53,35 +53,39 @@ public class QidCreator {
       log.with("treatment_code", treatmentCode).error(UNKNOWN_COUNTRY_ERROR);
       throw new IllegalArgumentException();
     }
-    int questionnaireType = -1;
+
     if (treatmentCode.startsWith("HH")) {
-      if (country.equals("E")) {
-        questionnaireType = 1;
-      } else if (country.equals("W")) {
-        questionnaireType = 2;
-      } else if (country.equals("N")) {
-        questionnaireType = 4;
+      switch (country) {
+        case "E":
+          return 1;
+        case "W":
+          return 2;
+        case "N":
+          return 4;
       }
     } else if (treatmentCode.startsWith("CI")) {
-      if (country.equals("E")) {
-        questionnaireType = 21;
-      } else if (country.equals("W")) {
-        questionnaireType = 22;
-      } else if (country.equals("N")) {
-        questionnaireType = 24;
+      switch (country) {
+        case "E":
+          return 21;
+        case "W":
+          return 22;
+        case "N":
+          return 24;
       }
     } else if (treatmentCode.startsWith("CE")) {
-      if (country.equals("E")) {
-        questionnaireType = 31;
-      } else if (country.equals("W")) {
-        questionnaireType = 32;
-      } else if (country.equals("N")) {
-        questionnaireType = 34;
+      switch (country) {
+        case "E":
+          return 31;
+        case "W":
+          return 32;
+        case "N":
+          return 34;
       }
     } else {
       log.with("treatment_code", treatmentCode).error(UNEXPECTED_CASE_TYPE_ERROR);
       throw new IllegalArgumentException();
     }
-    return questionnaireType;
+
+    throw new RuntimeException(); // This code should be unreachable
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/utility/QidCreator.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/utility/QidCreator.java
@@ -1,10 +1,16 @@
 package uk.gov.ons.census.casesvc.utility;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 public class QidCreator {
+  private static final Logger log = LoggerFactory.getLogger(QidCreator.class);
+
+  private static final String UNKNOWN_COUNTRY_ERROR = "Unknown Country";
+  private static final String UNEXPECTED_CASE_TYPE_ERROR = "Unexpected Case Type";
 
   @Value("${qid.modulus}")
   private int modulus;
@@ -12,13 +18,20 @@ public class QidCreator {
   @Value("${qid.factor}")
   private int factor;
 
-  public long createQid(int questionnaireType, int trancheIdentifier, long uniqueNumber) {
+  public String createQid(String treatmentCode, int trancheIdentifier, long uniqueNumber) {
+    int questionnaireType = calculateQuestionnaireType(treatmentCode);
     String sourceDigits =
         String.format("%02d%01d%011d", questionnaireType, trancheIdentifier, uniqueNumber);
 
     int checkDigits = calculateCheckDigits(sourceDigits);
-
-    return Long.parseLong(String.format("%s%02d", sourceDigits, checkDigits));
+    if (checkDigits > 99) {
+      log.with("check_digits", checkDigits)
+          .with("modulus", modulus)
+          .with("factor", factor)
+          .error("Check Digits too long, must be 99 or less");
+      throw new IllegalStateException();
+    }
+    return String.format("%s%02d", sourceDigits, checkDigits);
   }
 
   private int calculateCheckDigits(String sourceDigits) {
@@ -29,5 +42,43 @@ public class QidCreator {
       remainder = (remainder * factor + temp) % modulus;
     }
     return remainder % modulus;
+  }
+
+  private int calculateQuestionnaireType(String treatmentCode) {
+    String country = treatmentCode.substring(treatmentCode.length() - 1);
+    if (!country.equals("E") && !country.equals("W") && !country.equals("N")) {
+      log.with("treatment_code", treatmentCode).error(UNKNOWN_COUNTRY_ERROR);
+      throw new IllegalArgumentException();
+    }
+    int questionnaireType = -1;
+    if (treatmentCode.startsWith("HH")) {
+      if (country.equals("E")) {
+        questionnaireType = 1;
+      } else if (country.equals("W")) {
+        questionnaireType = 2;
+      } else if (country.equals("N")) {
+        questionnaireType = 4;
+      }
+    } else if (treatmentCode.startsWith("CI")) {
+      if (country.equals("E")) {
+        questionnaireType = 21;
+      } else if (country.equals("W")) {
+        questionnaireType = 22;
+      } else if (country.equals("N")) {
+        questionnaireType = 24;
+      }
+    } else if (treatmentCode.startsWith("CE")) {
+      if (country.equals("E")) {
+        questionnaireType = 31;
+      } else if (country.equals("W")) {
+        questionnaireType = 32;
+      } else if (country.equals("N")) {
+        questionnaireType = 34;
+      }
+    } else {
+      log.with("treatment_code", treatmentCode).error(UNEXPECTED_CASE_TYPE_ERROR);
+      throw new IllegalArgumentException();
+    }
+    return questionnaireType;
   }
 }

--- a/src/main/java/uk/gov/ons/census/casesvc/utility/QidCreator.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/utility/QidCreator.java
@@ -1,0 +1,16 @@
+package uk.gov.ons.census.casesvc.utility;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class QidCreator {
+
+  public long createQid(int questionnaireType, int trancheIdentifier, long uniqueNumber) {
+
+    int checkDigits = 99;
+
+    return Long.parseLong(
+        String.format(
+            "%02d%01d%011d%02d", questionnaireType, trancheIdentifier, uniqueNumber, checkDigits));
+  }
+}

--- a/src/main/java/uk/gov/ons/census/casesvc/utility/QidCreator.java
+++ b/src/main/java/uk/gov/ons/census/casesvc/utility/QidCreator.java
@@ -18,7 +18,10 @@ public class QidCreator {
   @Value("${qid.factor}")
   private int factor;
 
-  public String createQid(String treatmentCode, int trancheIdentifier, long uniqueNumber) {
+  @Value("${qid.tranche-identifier}")
+  private int trancheIdentifier;
+
+  public String createQid(String treatmentCode, long uniqueNumber) {
     int questionnaireType = calculateQuestionnaireType(treatmentCode);
     String sourceDigits =
         String.format("%02d%01d%011d", questionnaireType, trancheIdentifier, uniqueNumber);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,3 @@
+qid:
+  modulus: 1
+  factor: 1

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,3 +44,6 @@ iacservice:
     port: 8121
     username: admin
     password: secret
+
+qid:
+  tranche-identifier: 2

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,3 +33,14 @@ queueconfig:
 healthcheck:
   frequency: 1000 #milliseconds
   filename: /tmp/case-service-healthy
+
+iacservice:
+  generate-iacs-path: /iacs
+  pool-size-min: 500
+  pool-size-max: 1000
+  connection:
+    scheme: http
+    host: localhost
+    port: 8121
+    username: admin
+    password: secret

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQL94Dialect
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
     properties:
       hibernate:
         default_schema: casesvcv2

--- a/src/test/java/uk/gov/ons/census/casesvc/healthcheck/HeathCheckIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/healthcheck/HeathCheckIT.java
@@ -26,12 +26,11 @@ public class HeathCheckIT {
   public void testHappyPath() throws IOException {
     Path path = Paths.get(fileName);
 
-    try(BufferedReader bufferedReader = Files.newBufferedReader(path)) {
+    try (BufferedReader bufferedReader = Files.newBufferedReader(path)) {
       String fileLine = bufferedReader.readLine();
       String now = LocalDateTime.now().toString();
 
       assertEquals(now.substring(0, 16), fileLine.substring(0, 16));
     }
   }
-
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
@@ -22,7 +22,7 @@ import uk.gov.ons.census.casesvc.model.dto.CaseCreatedEvent;
 import uk.gov.ons.census.casesvc.model.dto.CreateCaseSample;
 import uk.gov.ons.census.casesvc.model.entity.Case;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
-import uk.gov.ons.census.casesvc.uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
+import uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
 
 @ContextConfiguration
 @ActiveProfiles("test")
@@ -66,13 +66,15 @@ public class SampleReceiverIT {
     // THEN
     ObjectMapper objectMapper = new ObjectMapper();
 
-    String actualMessage = queue1.poll(5, TimeUnit.SECONDS);
+    String actualMessage = queue1.poll(10, TimeUnit.SECONDS);
+    assertNotNull("Did not receive message before timeout", actualMessage);
     CaseCreatedEvent caseCreatedEvent =
         objectMapper.readValue(actualMessage, CaseCreatedEvent.class);
     assertNotNull(caseCreatedEvent);
     assertEquals("rm", caseCreatedEvent.getEvent().getChannel());
 
-    actualMessage = queue2.poll(5, TimeUnit.SECONDS);
+    actualMessage = queue2.poll(10, TimeUnit.SECONDS);
+    assertNotNull("Did not receive message before timeout", actualMessage);
     caseCreatedEvent = objectMapper.readValue(actualMessage, CaseCreatedEvent.class);
     assertNotNull(caseCreatedEvent);
     assertEquals("rm", caseCreatedEvent.getEvent().getChannel());

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
@@ -58,6 +58,7 @@ public class SampleReceiverIT {
 
     CreateCaseSample createCaseSample = new CreateCaseSample();
     createCaseSample.setPostcode("ABC123");
+    createCaseSample.setRgn("E12000009");
 
     // WHEN
     rabbitQueueHelper.sendMessage(inboundQueue, createCaseSample);

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
@@ -59,6 +59,7 @@ public class SampleReceiverIT {
     CreateCaseSample createCaseSample = new CreateCaseSample();
     createCaseSample.setPostcode("ABC123");
     createCaseSample.setRgn("E12000009");
+    createCaseSample.setTreatmentCode("HH_LF3R2E");
 
     // WHEN
     rabbitQueueHelper.sendMessage(inboundQueue, createCaseSample);
@@ -71,13 +72,13 @@ public class SampleReceiverIT {
     CaseCreatedEvent caseCreatedEvent =
         objectMapper.readValue(actualMessage, CaseCreatedEvent.class);
     assertNotNull(caseCreatedEvent);
-    assertEquals("rm", caseCreatedEvent.getEvent().getChannel());
+    assertEquals("RM", caseCreatedEvent.getEvent().getChannel());
 
     actualMessage = queue2.poll(10, TimeUnit.SECONDS);
     assertNotNull("Did not receive message before timeout", actualMessage);
     caseCreatedEvent = objectMapper.readValue(actualMessage, CaseCreatedEvent.class);
     assertNotNull(caseCreatedEvent);
-    assertEquals("rm", caseCreatedEvent.getEvent().getChannel());
+    assertEquals("RM", caseCreatedEvent.getEvent().getChannel());
 
     List<Case> caseList = caseRepository.findAll();
     assertEquals(1, caseList.size());

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverIT.java
@@ -19,9 +19,10 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.census.casesvc.model.dto.CaseCreatedEvent;
-import uk.gov.ons.census.casesvc.model.dto.FooBar;
+import uk.gov.ons.census.casesvc.model.dto.CreateCaseSample;
 import uk.gov.ons.census.casesvc.model.entity.Case;
 import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
+import uk.gov.ons.census.casesvc.uk.gov.ons.census.casesvc.testutil.RabbitQueueHelper;
 
 @ContextConfiguration
 @ActiveProfiles("test")
@@ -55,12 +56,11 @@ public class SampleReceiverIT {
     BlockingQueue<String> queue1 = rabbitQueueHelper.listen(emitCaseEventRhQueue);
     BlockingQueue<String> queue2 = rabbitQueueHelper.listen(emitCaseEventActionQueue);
 
-    FooBar fooBar = new FooBar();
-    fooBar.setFoo("bar");
-    fooBar.setTest("noodles");
+    CreateCaseSample createCaseSample = new CreateCaseSample();
+    createCaseSample.setPostcode("ABC123");
 
     // WHEN
-    rabbitQueueHelper.sendMessage(inboundQueue, fooBar);
+    rabbitQueueHelper.sendMessage(inboundQueue, createCaseSample);
 
     // THEN
     ObjectMapper objectMapper = new ObjectMapper();
@@ -78,6 +78,6 @@ public class SampleReceiverIT {
 
     List<Case> caseList = caseRepository.findAll();
     assertEquals(1, caseList.size());
-    assertEquals("bar", caseList.get(0).getStuff());
+    assertEquals("ABC123", caseList.get(0).getPostcode());
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverTest.java
@@ -1,0 +1,157 @@
+package uk.gov.ons.census.casesvc.messaging;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.ons.census.casesvc.iac.IacDispenser;
+import uk.gov.ons.census.casesvc.model.dto.CaseCreatedEvent;
+import uk.gov.ons.census.casesvc.model.dto.CreateCaseSample;
+import uk.gov.ons.census.casesvc.model.entity.Case;
+import uk.gov.ons.census.casesvc.model.entity.Event;
+import uk.gov.ons.census.casesvc.model.entity.UacQidLink;
+import uk.gov.ons.census.casesvc.model.repository.CaseRepository;
+import uk.gov.ons.census.casesvc.model.repository.EventRepository;
+import uk.gov.ons.census.casesvc.model.repository.UacQidLinkRepository;
+import uk.gov.ons.census.casesvc.utility.QidCreator;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SampleReceiverTest {
+
+  @InjectMocks private SampleReceiver underTest;
+
+  @Mock private CaseRepository caseRepository;
+  @Mock private UacQidLinkRepository uacQidLinkRepository;
+  @Mock private EventRepository eventRepository;
+  @Mock private RabbitTemplate rabbitTemplate;
+  @Mock private IacDispenser iacDispenser;
+  @Mock private QidCreator qidCreator;
+
+  @Test
+  public void testHappyPath() {
+    // Given
+    CreateCaseSample createCaseSample = new CreateCaseSample();
+    createCaseSample.setAddressLine1("123 Fake Street");
+    createCaseSample.setRgn("E999");
+    when(uacQidLinkRepository.saveAndFlush(any()))
+        .then(
+            obj -> {
+              UacQidLink uacQidLink = obj.getArgument(0);
+              uacQidLink.setUniqueNumber(12345L);
+              return uacQidLink;
+            });
+
+    when(caseRepository.saveAndFlush(any())).then(obj -> obj.getArgument(0));
+
+    when(caseRepository.saveAndFlush(any()))
+        .then(
+            obj -> {
+              Case caze = obj.getArgument(0);
+              caze.setCaseRef(123456789L);
+              return caze;
+            });
+
+    ReflectionTestUtils.setField(underTest, "emitCaseEventExchange", "myExchange");
+
+    String uac = "abcd-1234-xyza-4321";
+    when(iacDispenser.getIacCode()).thenReturn(uac);
+
+    long qid = 1234567891011125L;
+    when(qidCreator.createQid(anyInt(), anyInt(), anyLong())).thenReturn(qid);
+
+    // When
+    underTest.receiveMessage(createCaseSample);
+
+    // Then
+    ArgumentCaptor<CaseCreatedEvent> emittedMessageArgCaptor =
+        ArgumentCaptor.forClass(CaseCreatedEvent.class);
+    verify(rabbitTemplate)
+        .convertAndSend(eq("myExchange"), eq(""), emittedMessageArgCaptor.capture());
+    CaseCreatedEvent caseCreatedEvent = emittedMessageArgCaptor.getValue();
+    assertEquals("123456789", caseCreatedEvent.getPayload().getCollectionCase().getCaseRef());
+    assertEquals(
+        "123 Fake Street",
+        caseCreatedEvent.getPayload().getCollectionCase().getAddress().getAddressLine1());
+    verify(iacDispenser).getIacCode();
+    ArgumentCaptor<UacQidLink> uacQidLinkArgumentCaptor = ArgumentCaptor.forClass(UacQidLink.class);
+    verify(uacQidLinkRepository).save(uacQidLinkArgumentCaptor.capture());
+    UacQidLink uacQidLink = uacQidLinkArgumentCaptor.getValue();
+    assertEquals(uac, uacQidLink.getUac());
+    assertEquals(qid, uacQidLink.getQid().longValue());
+    ArgumentCaptor<Event> eventArgumentCaptor = ArgumentCaptor.forClass(Event.class);
+    verify(eventRepository).save(eventArgumentCaptor.capture());
+    Event event = eventArgumentCaptor.getValue();
+    assertEquals("Case created", event.getEventDescription());
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testDatabaseBlowsUp(){
+    // Given
+    CreateCaseSample createCaseSample = new CreateCaseSample();
+    createCaseSample.setAddressLine1("123 Fake Street");
+    createCaseSample.setRgn("E999");
+    when(uacQidLinkRepository.saveAndFlush(any()))
+        .thenThrow(new RuntimeException());
+
+    // When
+    underTest.receiveMessage(createCaseSample);
+
+    // Then
+
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testRabbitBlowsUp(){
+    // Given
+    CreateCaseSample createCaseSample = new CreateCaseSample();
+    createCaseSample.setAddressLine1("123 Fake Street");
+    createCaseSample.setRgn("E999");
+    when(uacQidLinkRepository.saveAndFlush(any()))
+        .then(
+            obj -> {
+              UacQidLink uacQidLink = obj.getArgument(0);
+              uacQidLink.setUniqueNumber(12345L);
+              return uacQidLink;
+            });
+
+    when(caseRepository.saveAndFlush(any())).then(obj -> obj.getArgument(0));
+
+    when(caseRepository.saveAndFlush(any()))
+        .then(
+            obj -> {
+              Case caze = obj.getArgument(0);
+              caze.setCaseRef(123456789L);
+              return caze;
+            });
+
+    ReflectionTestUtils.setField(underTest, "emitCaseEventExchange", "myExchange");
+
+    String uac = "abcd-1234-xyza-4321";
+    when(iacDispenser.getIacCode()).thenReturn(uac);
+
+    long qid = 1234567891011125L;
+    when(qidCreator.createQid(anyInt(), anyInt(), anyLong())).thenReturn(qid);
+
+    doThrow(new RuntimeException()).when(rabbitTemplate).convertAndSend(anyString(), anyString(), any(CaseCreatedEvent.class));
+
+    // When
+    underTest.receiveMessage(createCaseSample);
+
+  }
+
+}

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverTest.java
@@ -81,7 +81,7 @@ public class SampleReceiverTest {
     when(iacDispenser.getIacCode()).thenReturn(uac);
 
     String qid = "1234567891011125";
-    when(qidCreator.createQid(eq("HH_LF3R2E"), anyInt(), anyLong())).thenReturn(qid);
+    when(qidCreator.createQid(eq("HH_LF3R2E"), anyLong())).thenReturn(qid);
 
     // When
     underTest.receiveMessage(createCaseSample);
@@ -145,6 +145,7 @@ public class SampleReceiverTest {
     underTest.receiveMessage(createCaseSample);
 
     // Then
+    // Expected Exception is raised
 
   }
 
@@ -179,7 +180,7 @@ public class SampleReceiverTest {
     when(iacDispenser.getIacCode()).thenReturn(uac);
 
     String qid = "1234567891011125";
-    when(qidCreator.createQid(eq("HH_LF3R2E"), anyInt(), anyLong())).thenReturn(qid);
+    when(qidCreator.createQid(eq("HH_LF3R2E"), anyLong())).thenReturn(qid);
 
     doThrow(new RuntimeException())
         .when(rabbitTemplate)
@@ -187,5 +188,8 @@ public class SampleReceiverTest {
 
     // When
     underTest.receiveMessage(createCaseSample);
+
+    // Then
+    // Expected Exception is raised
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverTest.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.census.casesvc.messaging;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -10,16 +11,21 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.ons.census.casesvc.model.entity.CaseState.ACTIONABLE;
 
+import java.time.LocalDateTime;
+import ma.glasnost.orika.MapperFacade;
+import ma.glasnost.orika.impl.DefaultMapperFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
-import uk.gov.ons.census.casesvc.iac.IacDispenser;
+import uk.gov.ons.census.casesvc.utility.IacDispenser;
 import uk.gov.ons.census.casesvc.model.dto.CaseCreatedEvent;
 import uk.gov.ons.census.casesvc.model.dto.CreateCaseSample;
 import uk.gov.ons.census.casesvc.model.entity.Case;
@@ -33,14 +39,24 @@ import uk.gov.ons.census.casesvc.utility.QidCreator;
 @RunWith(MockitoJUnitRunner.class)
 public class SampleReceiverTest {
 
-  @InjectMocks private SampleReceiver underTest;
+  @InjectMocks
+  private SampleReceiver underTest;
 
-  @Mock private CaseRepository caseRepository;
-  @Mock private UacQidLinkRepository uacQidLinkRepository;
-  @Mock private EventRepository eventRepository;
-  @Mock private RabbitTemplate rabbitTemplate;
-  @Mock private IacDispenser iacDispenser;
-  @Mock private QidCreator qidCreator;
+  @Mock
+  private CaseRepository caseRepository;
+  @Mock
+  private UacQidLinkRepository uacQidLinkRepository;
+  @Mock
+  private EventRepository eventRepository;
+  @Mock
+  private RabbitTemplate rabbitTemplate;
+  @Mock
+  private IacDispenser iacDispenser;
+  @Mock
+  private QidCreator qidCreator;
+
+  @Spy
+  private MapperFacade mapperFacade = new DefaultMapperFactory.Builder().build().getMapperFacade();
 
   @Test
   public void testHappyPath() {
@@ -78,6 +94,7 @@ public class SampleReceiverTest {
     underTest.receiveMessage(createCaseSample);
 
     // Then
+    // Check the emitted event
     ArgumentCaptor<CaseCreatedEvent> emittedMessageArgCaptor =
         ArgumentCaptor.forClass(CaseCreatedEvent.class);
     verify(rabbitTemplate)
@@ -87,20 +104,47 @@ public class SampleReceiverTest {
     assertEquals(
         "123 Fake Street",
         caseCreatedEvent.getPayload().getCollectionCase().getAddress().getAddressLine1());
+    assertEquals("E", caseCreatedEvent.getPayload().getCollectionCase().getAddress().getRegion());
+    assertEquals("ACTIONABLE", caseCreatedEvent.getPayload().getCollectionCase().getState());
+    assertEquals("Census", caseCreatedEvent.getPayload().getCollectionCase().getSurvey());
+    assertEquals("rm", caseCreatedEvent.getEvent().getChannel());
+    assertEquals("CaseCreated", caseCreatedEvent.getEvent().getType());
+    String now = LocalDateTime.now().toString();
+    assertEquals(now.substring(0, 16), caseCreatedEvent.getEvent().getDateTime().substring(0, 16));
+
+    // Check IAC is retrieved
     verify(iacDispenser).getIacCode();
+
+    // Check IAC and QID are linked correctly
     ArgumentCaptor<UacQidLink> uacQidLinkArgumentCaptor = ArgumentCaptor.forClass(UacQidLink.class);
     verify(uacQidLinkRepository).save(uacQidLinkArgumentCaptor.capture());
     UacQidLink uacQidLink = uacQidLinkArgumentCaptor.getValue();
     assertEquals(uac, uacQidLink.getUac());
     assertEquals(qid, uacQidLink.getQid().longValue());
+
+    // Check case event is stored
     ArgumentCaptor<Event> eventArgumentCaptor = ArgumentCaptor.forClass(Event.class);
     verify(eventRepository).save(eventArgumentCaptor.capture());
     Event event = eventArgumentCaptor.getValue();
     assertEquals("Case created", event.getEventDescription());
+
+    // Check case is stored in the database
+    ArgumentCaptor<Case> caseArgumentCaptor =
+        ArgumentCaptor.forClass(Case.class);
+    verify(caseRepository).saveAndFlush(caseArgumentCaptor.capture());
+    Case caze = caseArgumentCaptor.getValue();
+    assertEquals(
+        "123 Fake Street",
+        caze.getAddressLine1());
+    assertEquals(ACTIONABLE, caze.getState());
+
+    // Check sample gets mapped to a case
+    verify(mapperFacade).map(any(CreateCaseSample.class), eq(Case.class));
+
   }
 
   @Test(expected = RuntimeException.class)
-  public void testDatabaseBlowsUp(){
+  public void testDatabaseBlowsUp() {
     // Given
     CreateCaseSample createCaseSample = new CreateCaseSample();
     createCaseSample.setAddressLine1("123 Fake Street");
@@ -116,7 +160,7 @@ public class SampleReceiverTest {
   }
 
   @Test(expected = RuntimeException.class)
-  public void testRabbitBlowsUp(){
+  public void testRabbitBlowsUp() {
     // Given
     CreateCaseSample createCaseSample = new CreateCaseSample();
     createCaseSample.setAddressLine1("123 Fake Street");
@@ -147,7 +191,8 @@ public class SampleReceiverTest {
     long qid = 1234567891011125L;
     when(qidCreator.createQid(anyInt(), anyInt(), anyLong())).thenReturn(qid);
 
-    doThrow(new RuntimeException()).when(rabbitTemplate).convertAndSend(anyString(), anyString(), any(CaseCreatedEvent.class));
+    doThrow(new RuntimeException()).when(rabbitTemplate)
+        .convertAndSend(anyString(), anyString(), any(CaseCreatedEvent.class));
 
     // When
     underTest.receiveMessage(createCaseSample);

--- a/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/messaging/SampleReceiverTest.java
@@ -2,7 +2,6 @@ package uk.gov.ons.census.casesvc.messaging;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;

--- a/src/test/java/uk/gov/ons/census/casesvc/testutil/RabbitQueueHelper.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/testutil/RabbitQueueHelper.java
@@ -1,4 +1,4 @@
-package uk.gov.ons.census.casesvc.uk.gov.ons.census.casesvc.testutil;
+package uk.gov.ons.census.casesvc.testutil;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;

--- a/src/test/java/uk/gov/ons/census/casesvc/uk/gov/ons/census/casesvc/testutil/RabbitQueueHelper.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/uk/gov/ons/census/casesvc/testutil/RabbitQueueHelper.java
@@ -1,4 +1,4 @@
-package uk.gov.ons.census.casesvc.messaging;
+package uk.gov.ons.census.casesvc.uk.gov.ons.census.casesvc.testutil;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;

--- a/src/test/java/uk/gov/ons/census/casesvc/utility/IacDispenserTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/utility/IacDispenserTest.java
@@ -1,0 +1,59 @@
+package uk.gov.ons.census.casesvc.utility;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.ons.census.casesvc.client.InternetAccessCodeSvcClient;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IacDispenserTest {
+  @Mock private InternetAccessCodeSvcClient internetAccessCodeSvcClient;
+
+  @InjectMocks private IacDispenser underTest;
+
+  @Test
+  public void testDispenserDispenses() {
+    // Given
+    ReflectionTestUtils.setField(underTest, "iacPoolSizeMin", 500);
+    ReflectionTestUtils.setField(underTest, "iacPoolSizeMax", 1000);
+    when(internetAccessCodeSvcClient.generateIACs(anyInt()))
+        .thenReturn(Collections.singletonList("Foo"));
+
+    // When
+    String actualResult = underTest.getIacCode();
+
+    // Then
+    assertEquals("Foo", actualResult);
+  }
+
+  @Test
+  public void testDispenserTopsItselfUp() {
+    // Given
+    List<String> iacCodes = new ArrayList<>(1000);
+    for (int i = 0; i < 1000; i++) {
+      iacCodes.add("Bar");
+    }
+    ReflectionTestUtils.setField(underTest, "iacPoolSizeMin", 500);
+    ReflectionTestUtils.setField(underTest, "iacPoolSizeMax", 1000);
+    when(internetAccessCodeSvcClient.generateIACs(anyInt())).thenReturn(iacCodes);
+
+    // When
+    for (int i = 0; i < 502; i++) {
+      underTest.getIacCode();
+    }
+
+    // Then
+    verify(internetAccessCodeSvcClient, times(2)).generateIACs(anyInt());
+  }
+}

--- a/src/test/java/uk/gov/ons/census/casesvc/utility/IacDispenserTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/utility/IacDispenserTest.java
@@ -1,5 +1,12 @@
 package uk.gov.ons.census.casesvc.utility;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -7,14 +14,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.ons.census.casesvc.client.InternetAccessCodeSvcClient;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class IacDispenserTest {

--- a/src/test/java/uk/gov/ons/census/casesvc/utility/QidCreatorTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/utility/QidCreatorTest.java
@@ -2,17 +2,23 @@ package uk.gov.ons.census.casesvc.utility;
 
 import static org.junit.Assert.assertEquals;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @RunWith(MockitoJUnitRunner.class)
 public class QidCreatorTest {
 
-  @InjectMocks
-  private QidCreator underTest;
+  @InjectMocks private QidCreator underTest;
+
+  @Before
+  public void setUp() {
+    ReflectionTestUtils.setField(underTest, "modulus", 33);
+    ReflectionTestUtils.setField(underTest, "factor", 802);
+  }
 
   @Test
   public void testValidQid() {
@@ -22,7 +28,7 @@ public class QidCreatorTest {
     long result = underTest.createQid(12, 2, 12345);
 
     // Then
-    assertEquals(1220000001234599L, result);
+    assertEquals(1220000001234502L, result);
   }
 
   @Test
@@ -34,6 +40,6 @@ public class QidCreatorTest {
 
     // Then
     String stringResult = Long.toString(result);
-    assertEquals("99", stringResult.substring(stringResult.length() - 2));
+    assertEquals("02", stringResult.substring(stringResult.length() - 2));
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/utility/QidCreatorTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/utility/QidCreatorTest.java
@@ -10,11 +10,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 @RunWith(MockitoJUnitRunner.class)
 public class QidCreatorTest {
 
-  @Autowired private QidCreator underTest;
-
   @Test
   public void testValidQid() {
     // Given
+    QidCreator underTest = new QidCreator();
 
     // When
     long result = underTest.createQid(12, 2, 12345);
@@ -26,6 +25,7 @@ public class QidCreatorTest {
   @Test
   public void testValidCheckDigits() {
     // Given
+    QidCreator underTest = new QidCreator();
 
     // When
     long result = underTest.createQid(12, 2, 12345);

--- a/src/test/java/uk/gov/ons/census/casesvc/utility/QidCreatorTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/utility/QidCreatorTest.java
@@ -2,7 +2,6 @@ package uk.gov.ons.census.casesvc.utility;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -14,32 +13,169 @@ public class QidCreatorTest {
 
   @InjectMocks private QidCreator underTest;
 
-  @Before
-  public void setUp() {
-    ReflectionTestUtils.setField(underTest, "modulus", 33);
-    ReflectionTestUtils.setField(underTest, "factor", 802);
-  }
-
   @Test
   public void testValidQid() {
     // Given
-
+    ReflectionTestUtils.setField(underTest, "modulus", 33);
+    ReflectionTestUtils.setField(underTest, "factor", 802);
     // When
-    long result = underTest.createQid(12, 2, 12345);
+    String result = underTest.createQid("HH_LF3R2E", 2, 12345);
 
     // Then
-    assertEquals(1220000001234502L, result);
+    assertEquals("0120000001234524", result);
   }
 
   @Test
   public void testValidCheckDigits() {
     // Given
-
+    ReflectionTestUtils.setField(underTest, "modulus", 33);
+    ReflectionTestUtils.setField(underTest, "factor", 802);
     // When
-    long result = underTest.createQid(12, 2, 12345);
+    String result = underTest.createQid("HH_LF3R2E", 2, 12345);
 
     // Then
-    String stringResult = Long.toString(result);
-    assertEquals("02", stringResult.substring(stringResult.length() - 2));
+    assertEquals("24", result.substring(result.length() - 2));
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testTooManyCheckDigits() {
+    // Given
+    ReflectionTestUtils.setField(underTest, "modulus", 4312);
+    ReflectionTestUtils.setField(underTest, "factor", 802);
+    // When
+    String result = underTest.createQid("HH_LF3R2E", 2, 12345);
+
+    // Then
+
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeEnglandHousehold() {
+    // Given
+    ReflectionTestUtils.setField(underTest, "modulus", 33);
+    ReflectionTestUtils.setField(underTest, "factor", 802);
+    // When
+    String result = underTest.createQid("HH_LF3R2E", 2, 12345);
+
+    // Then
+    assertEquals("01", result.substring(0, 2));
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeWalesHousehold() {
+    // Given
+    ReflectionTestUtils.setField(underTest, "modulus", 33);
+    ReflectionTestUtils.setField(underTest, "factor", 802);
+    // When
+    String result = underTest.createQid("HH_LF3R2W", 2, 12345);
+
+    // Then
+    assertEquals("02", result.substring(0, 2));
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeNorthernIrelandHousehold() {
+    // Given
+    ReflectionTestUtils.setField(underTest, "modulus", 33);
+    ReflectionTestUtils.setField(underTest, "factor", 802);
+    // When
+    String result = underTest.createQid("HH_LF3R2N", 2, 12345);
+
+    // Then
+    assertEquals("04", result.substring(0, 2));
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeEnglandIndividual() {
+    // Given
+    ReflectionTestUtils.setField(underTest, "modulus", 33);
+    ReflectionTestUtils.setField(underTest, "factor", 802);
+    // When
+    String result = underTest.createQid("CI_LF3R2E", 2, 12345);
+
+    // Then
+    assertEquals("21", result.substring(0, 2));
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeWalesIndividual() {
+    // Given
+    ReflectionTestUtils.setField(underTest, "modulus", 33);
+    ReflectionTestUtils.setField(underTest, "factor", 802);
+    // When
+    String result = underTest.createQid("CI_LF3R2W", 2, 12345);
+
+    // Then
+    assertEquals("22", result.substring(0, 2));
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeNorthernIrelandIndividual() {
+    // Given
+    ReflectionTestUtils.setField(underTest, "modulus", 33);
+    ReflectionTestUtils.setField(underTest, "factor", 802);
+    // When
+    String result = underTest.createQid("CI_LF3R2N", 2, 12345);
+
+    // Then
+    assertEquals("24", result.substring(0, 2));
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeEnglandCommunalEstablishment() {
+    // Given
+    ReflectionTestUtils.setField(underTest, "modulus", 33);
+    ReflectionTestUtils.setField(underTest, "factor", 802);
+    // When
+    String result = underTest.createQid("CE_LF3R2E", 2, 12345);
+
+    // Then
+    assertEquals("31", result.substring(0, 2));
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeWalesCommunalEstablishment() {
+    // Given
+    ReflectionTestUtils.setField(underTest, "modulus", 33);
+    ReflectionTestUtils.setField(underTest, "factor", 802);
+    // When
+    String result = underTest.createQid("CE_LF3R2W", 2, 12345);
+
+    // Then
+    assertEquals("32", result.substring(0, 2));
+  }
+
+  @Test
+  public void testValidQuestionnaireTypeNorthernIrelandCommunalEstablishment() {
+    // Given
+    ReflectionTestUtils.setField(underTest, "modulus", 33);
+    ReflectionTestUtils.setField(underTest, "factor", 802);
+    // When
+    String result = underTest.createQid("CE_LF3R2N", 2, 12345);
+
+    // Then
+    assertEquals("34", result.substring(0, 2));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidCountryTreatmentCode() {
+    // Given
+    ReflectionTestUtils.setField(underTest, "modulus", 33);
+    ReflectionTestUtils.setField(underTest, "factor", 802);
+    // When
+    String result = underTest.createQid("HH_LF3R2Z", 2, 12345);
+
+    // Then
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidCaseType() {
+    // Given
+    ReflectionTestUtils.setField(underTest, "modulus", 33);
+    ReflectionTestUtils.setField(underTest, "factor", 802);
+    // When
+    String result = underTest.createQid("ZZ_LF3R2E", 2, 12345);
+
+    // Then
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/utility/QidCreatorTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/utility/QidCreatorTest.java
@@ -4,16 +4,19 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @RunWith(MockitoJUnitRunner.class)
 public class QidCreatorTest {
 
+  @InjectMocks
+  private QidCreator underTest;
+
   @Test
   public void testValidQid() {
     // Given
-    QidCreator underTest = new QidCreator();
 
     // When
     long result = underTest.createQid(12, 2, 12345);
@@ -25,7 +28,6 @@ public class QidCreatorTest {
   @Test
   public void testValidCheckDigits() {
     // Given
-    QidCreator underTest = new QidCreator();
 
     // When
     long result = underTest.createQid(12, 2, 12345);

--- a/src/test/java/uk/gov/ons/census/casesvc/utility/QidCreatorTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/utility/QidCreatorTest.java
@@ -18,8 +18,9 @@ public class QidCreatorTest {
     // Given
     ReflectionTestUtils.setField(underTest, "modulus", 33);
     ReflectionTestUtils.setField(underTest, "factor", 802);
+    ReflectionTestUtils.setField(underTest, "trancheIdentifier", 2);
     // When
-    String result = underTest.createQid("HH_LF3R2E", 2, 12345);
+    String result = underTest.createQid("HH_LF3R2E", 12345);
 
     // Then
     assertEquals("0120000001234524", result);
@@ -30,8 +31,9 @@ public class QidCreatorTest {
     // Given
     ReflectionTestUtils.setField(underTest, "modulus", 33);
     ReflectionTestUtils.setField(underTest, "factor", 802);
+    ReflectionTestUtils.setField(underTest, "trancheIdentifier", 2);
     // When
-    String result = underTest.createQid("HH_LF3R2E", 2, 12345);
+    String result = underTest.createQid("HH_LF3R2E", 12345);
 
     // Then
     assertEquals("24", result.substring(result.length() - 2));
@@ -42,10 +44,12 @@ public class QidCreatorTest {
     // Given
     ReflectionTestUtils.setField(underTest, "modulus", 4312);
     ReflectionTestUtils.setField(underTest, "factor", 802);
+    ReflectionTestUtils.setField(underTest, "trancheIdentifier", 2);
     // When
-    String result = underTest.createQid("HH_LF3R2E", 2, 12345);
+    String result = underTest.createQid("HH_LF3R2E",12345);
 
     // Then
+    // Expected Exception is raised
 
   }
 
@@ -54,8 +58,9 @@ public class QidCreatorTest {
     // Given
     ReflectionTestUtils.setField(underTest, "modulus", 33);
     ReflectionTestUtils.setField(underTest, "factor", 802);
+    ReflectionTestUtils.setField(underTest, "trancheIdentifier", 2);
     // When
-    String result = underTest.createQid("HH_LF3R2E", 2, 12345);
+    String result = underTest.createQid("HH_LF3R2E", 12345);
 
     // Then
     assertEquals("01", result.substring(0, 2));
@@ -66,8 +71,9 @@ public class QidCreatorTest {
     // Given
     ReflectionTestUtils.setField(underTest, "modulus", 33);
     ReflectionTestUtils.setField(underTest, "factor", 802);
+    ReflectionTestUtils.setField(underTest, "trancheIdentifier", 2);
     // When
-    String result = underTest.createQid("HH_LF3R2W", 2, 12345);
+    String result = underTest.createQid("HH_LF3R2W", 12345);
 
     // Then
     assertEquals("02", result.substring(0, 2));
@@ -78,8 +84,9 @@ public class QidCreatorTest {
     // Given
     ReflectionTestUtils.setField(underTest, "modulus", 33);
     ReflectionTestUtils.setField(underTest, "factor", 802);
+    ReflectionTestUtils.setField(underTest, "trancheIdentifier", 2);
     // When
-    String result = underTest.createQid("HH_LF3R2N", 2, 12345);
+    String result = underTest.createQid("HH_LF3R2N", 12345);
 
     // Then
     assertEquals("04", result.substring(0, 2));
@@ -90,8 +97,9 @@ public class QidCreatorTest {
     // Given
     ReflectionTestUtils.setField(underTest, "modulus", 33);
     ReflectionTestUtils.setField(underTest, "factor", 802);
+    ReflectionTestUtils.setField(underTest, "trancheIdentifier", 2);
     // When
-    String result = underTest.createQid("CI_LF3R2E", 2, 12345);
+    String result = underTest.createQid("CI_LF3R2E", 12345);
 
     // Then
     assertEquals("21", result.substring(0, 2));
@@ -102,8 +110,9 @@ public class QidCreatorTest {
     // Given
     ReflectionTestUtils.setField(underTest, "modulus", 33);
     ReflectionTestUtils.setField(underTest, "factor", 802);
+    ReflectionTestUtils.setField(underTest, "trancheIdentifier", 2);
     // When
-    String result = underTest.createQid("CI_LF3R2W", 2, 12345);
+    String result = underTest.createQid("CI_LF3R2W", 12345);
 
     // Then
     assertEquals("22", result.substring(0, 2));
@@ -114,8 +123,9 @@ public class QidCreatorTest {
     // Given
     ReflectionTestUtils.setField(underTest, "modulus", 33);
     ReflectionTestUtils.setField(underTest, "factor", 802);
+    ReflectionTestUtils.setField(underTest, "trancheIdentifier", 2);
     // When
-    String result = underTest.createQid("CI_LF3R2N", 2, 12345);
+    String result = underTest.createQid("CI_LF3R2N", 12345);
 
     // Then
     assertEquals("24", result.substring(0, 2));
@@ -126,8 +136,9 @@ public class QidCreatorTest {
     // Given
     ReflectionTestUtils.setField(underTest, "modulus", 33);
     ReflectionTestUtils.setField(underTest, "factor", 802);
+    ReflectionTestUtils.setField(underTest, "trancheIdentifier", 2);
     // When
-    String result = underTest.createQid("CE_LF3R2E", 2, 12345);
+    String result = underTest.createQid("CE_LF3R2E", 12345);
 
     // Then
     assertEquals("31", result.substring(0, 2));
@@ -138,8 +149,9 @@ public class QidCreatorTest {
     // Given
     ReflectionTestUtils.setField(underTest, "modulus", 33);
     ReflectionTestUtils.setField(underTest, "factor", 802);
+    ReflectionTestUtils.setField(underTest, "trancheIdentifier", 2);
     // When
-    String result = underTest.createQid("CE_LF3R2W", 2, 12345);
+    String result = underTest.createQid("CE_LF3R2W", 12345);
 
     // Then
     assertEquals("32", result.substring(0, 2));
@@ -150,8 +162,9 @@ public class QidCreatorTest {
     // Given
     ReflectionTestUtils.setField(underTest, "modulus", 33);
     ReflectionTestUtils.setField(underTest, "factor", 802);
+    ReflectionTestUtils.setField(underTest, "trancheIdentifier", 2);
     // When
-    String result = underTest.createQid("CE_LF3R2N", 2, 12345);
+    String result = underTest.createQid("CE_LF3R2N", 12345);
 
     // Then
     assertEquals("34", result.substring(0, 2));
@@ -162,10 +175,12 @@ public class QidCreatorTest {
     // Given
     ReflectionTestUtils.setField(underTest, "modulus", 33);
     ReflectionTestUtils.setField(underTest, "factor", 802);
+    ReflectionTestUtils.setField(underTest, "trancheIdentifier", 2);
     // When
-    String result = underTest.createQid("HH_LF3R2Z", 2, 12345);
+    String result = underTest.createQid("HH_LF3R2Z", 12345);
 
     // Then
+    // Expected Exception is raised
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -173,9 +188,11 @@ public class QidCreatorTest {
     // Given
     ReflectionTestUtils.setField(underTest, "modulus", 33);
     ReflectionTestUtils.setField(underTest, "factor", 802);
+    ReflectionTestUtils.setField(underTest, "trancheIdentifier", 2);
     // When
-    String result = underTest.createQid("ZZ_LF3R2E", 2, 12345);
+    String result = underTest.createQid("ZZ_LF3R2E", 12345);
 
     // Then
+    // Expected Exception is raised
   }
 }

--- a/src/test/java/uk/gov/ons/census/casesvc/utility/QidCreatorTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/utility/QidCreatorTest.java
@@ -46,7 +46,7 @@ public class QidCreatorTest {
     ReflectionTestUtils.setField(underTest, "factor", 802);
     ReflectionTestUtils.setField(underTest, "trancheIdentifier", 2);
     // When
-    String result = underTest.createQid("HH_LF3R2E",12345);
+    String result = underTest.createQid("HH_LF3R2E", 12345);
 
     // Then
     // Expected Exception is raised

--- a/src/test/java/uk/gov/ons/census/casesvc/utility/QidCreatorTest.java
+++ b/src/test/java/uk/gov/ons/census/casesvc/utility/QidCreatorTest.java
@@ -1,0 +1,37 @@
+package uk.gov.ons.census.casesvc.utility;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@RunWith(MockitoJUnitRunner.class)
+public class QidCreatorTest {
+
+  @Autowired private QidCreator underTest;
+
+  @Test
+  public void testValidQid() {
+    // Given
+
+    // When
+    long result = underTest.createQid(12, 2, 12345);
+
+    // Then
+    assertEquals(1220000001234599L, result);
+  }
+
+  @Test
+  public void testValidCheckDigits() {
+    // Given
+
+    // When
+    long result = underTest.createQid(12, 2, 12345);
+
+    // Then
+    String stringResult = Long.toString(result);
+    assertEquals("99", stringResult.substring(stringResult.length() - 2));
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,3 +4,7 @@ spring:
 
   rabbitmq:
     port: 35672
+
+iacservice:
+  connection:
+    port: 18121

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -8,3 +8,7 @@ spring:
 iacservice:
   connection:
     port: 18121
+
+qid:
+  modulus: 1
+  factor: 1

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -1,13 +1,13 @@
 version: '2.1'
 services:
  postgres:
-  container_name: postgres-action-it
+  container_name: postgres-case-it
   image: sdcplatform/ras-rm-docker-postgres
   ports:
    - "15432:5432"
 
  rabbitmq:
-  container_name: rabbitmq-action-it
+  container_name: rabbitmq-case-it
   image: rabbitmq:3.6.10-management
   ports:
     - "34369:4369"
@@ -16,3 +16,55 @@ services:
     - "35672:5672"
     - "46671:15671"
     - "46672:15672"
+
+ redis:
+  container_name: redis-case-it
+  image: redis:3.2.9
+  ports:
+  - "17379:6379"
+
+ iac:
+  container_name: iac-case-it
+  image: eu.gcr.io/census-rm-ci/rm/census-rm-iacsvc
+  ports:
+  - "18121:8121"
+  - "15121:5121"
+  - "18221:8221"
+  external_links:
+  - postgres-case-it
+  - rabbitmq-case-it
+  - redis-case-it
+  environment:
+  - SECURITY_BASIC_ENABLED=true
+  - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres-case-it:5432/postgres?sslmode=disable
+  - LIQUIBASE_URL=jdbc:postgresql://postgres-case-it:5432/postgres
+  - RABBITMQ_HOST=rabbitmq-case-it
+  - RABBITMQ_PORT=5672
+  - REDIS_HOST=redis-case-it
+  - CASE_SVC_CONNECTION_CONFIG_HOST=foobar
+  - CASE_SVC_CONNECTION_CONFIG_PORT=666
+  - JAVA_OPTS=-Xmx128m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5121
+  - LIQUIBASE_USER=postgres
+  - LIQUIBASE_PASSWORD=postgres
+  - SPRING_DATASOURCE_USERNAME=postgres
+  - SPRING_DATASOURCE_PASSWORD=postgres
+  - SPRING_ZIPKIN_ENABLED=true
+  - SPRING_ZIPKIN_BASEURL=http://foobar:666/
+  healthcheck:
+   test: ["CMD", "curl", "-f", "http://localhost:8121/info"]
+   interval: 30s
+   timeout: 10s
+   retries: 10
+
+ start_dependencies:
+  image: dadarek/wait-for-dependencies
+  depends_on:
+   iac:
+    condition: service_healthy
+
+# wait:
+#  image: waisbrot/wait
+#  links:
+#  - iac
+#  environment:
+#  - TARGETS=iac-case-it:8121

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -43,7 +43,7 @@ services:
   - REDIS_HOST=redis-case-it
   - CASE_SVC_CONNECTION_CONFIG_HOST=foobar
   - CASE_SVC_CONNECTION_CONFIG_PORT=666
-  - JAVA_OPTS=-Xmx128m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5121
+  - JAVA_OPTS=-Xmx128m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5121 -Dspring.profiles.active=dev
   - LIQUIBASE_USER=postgres
   - LIQUIBASE_PASSWORD=postgres
   - SPRING_DATASOURCE_USERNAME=postgres

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -61,10 +61,3 @@ services:
   depends_on:
    iac:
     condition: service_healthy
-
-# wait:
-#  image: waisbrot/wait
-#  links:
-#  - iac
-#  environment:
-#  - TARGETS=iac-case-it:8121


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need all the attributes against the case so we no longer have to call out to Redis to retrieve the sample attributes. We also need the sample attributes so that we can emit them to Respondent Home. 

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* We receive the sample as a JSON blob
* We map the sample message to a persistent case entity
* We generate a caseRef
* We add UAC code
* We generate a QID
* We link the caseRef, UAC and QID together
* We store the Case Created event in the database
* We construct a JSON message to be emitted to RH via RabbitMQ fanout
* Emit the case created JSON message
* Build and store Docker image in GCR

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
* `mvn clean install` to run unit and ITs
* Run acceptance tests from [this branch](https://github.com/ONSdigital/census-rm-acceptance-tests/pull/39)

**NOTE:** To run in IDE debugger, use: `-Dspring.profiles.active=dev`


# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/bXIR1AvP/447-rmc-33-stamp-sample-attributes-against-the-case-8
https://trello.com/c/jRjqBbgh/576-emit-casecreated-event-8